### PR TITLE
security: be more liberal in what kind of PEM files are accepted

### DIFF
--- a/src/org/spootnik/fleet/transport/redis.clj
+++ b/src/org/spootnik/fleet/transport/redis.clj
@@ -22,8 +22,8 @@
           (security/verify signer (:host decoded) msg sig)
           (>!! ch {:chan chan :msg decoded})
           (catch Exception e
-            (warn "received message with bad signature from "
-                  (:host decoded))))))))
+            (warn "unable to check signature of received message from "
+                  (:host decoded) e)))))))
 
 (defn rpool
   [{:keys [host port timeout max-active max-idle max-wait]


### PR DESCRIPTION
PEM decoding can lead to different kind of objects whose interfaces to
get the public or private key may differ. Try to accommodate for common
cases.
