### PR TITLE
hubot: avoid to use ')' after an URL

### DIFF
--- a/hubot/fleet.coffee
+++ b/hubot/fleet.coffee
@@ -17,7 +17,7 @@ class Fleet
 
   constructor: (@scenario, @client) ->
     history = (process.env.HUBOT_FLEET_SHOW_URL or process.env.HUBOT_FLEET_URL) + '#/history/' + @scenario
-    @client.send "executing " + scenario + " (waiting 2 seconds for acks, reporting to: " + history + ')'
+    @client.send "executing " + scenario + ", waiting 2 seconds for acks, reporting to: " + history
 
   process: (msg) ->
 


### PR DESCRIPTION
Such a character can be mistaken to be part of the URL
