### PR TITLE
client: ensure host is in environment map

### DIFF
--- a/agent/src/warp/client.go
+++ b/agent/src/warp/client.go
@@ -69,8 +69,9 @@ func NewClient(cfg Config) *Client {
 	env := MapEnvironment{Internal: envmap}
 
 	client := &Client{Config: cfg, Conn: nil, Logger: logger, Connected: false, Input: input, Output: output}
+	envmap["host"] = cfg.Host
 
-	go BuildEnv(logger, envmap)
+	go BuildEnv(logger, cfg.Host, envmap)
 
 	go func() {
 		for {

--- a/agent/src/warp/environment.go
+++ b/agent/src/warp/environment.go
@@ -55,7 +55,7 @@ func BuildPrefixedEnv(env map[string]string, prefix string, values map[string]in
 	}
 }
 
-func BuildEnv(logger *log.Logger, env map[string]string) {
+func BuildEnv(logger *log.Logger, host string, env map[string]string) {
 
 	for {
 		stdin := strings.NewReader("")
@@ -82,6 +82,7 @@ func BuildEnv(logger *log.Logger, env map[string]string) {
 		for k := range(env) {
 			delete(env, k)
 		}
+		env["host"] = host
 		BuildPrefixedEnv(env, "facter", outmap)
 		time.Sleep(120 * time.Second)
 	}


### PR DESCRIPTION
The prefixed environment change pushed the host out of the environment map, which means matches on hosts were not possible anymore.