### PR TITLE
warp: Allow several formats for scenarios

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: false
 language: clojure
-lein: lein2
+lein: lein
 jdk:
   - openjdk7
   - oraclejdk7

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,6 @@
 (defproject warp "0.7.1-SNAPSHOT"
   :main warp.main
-  :plugins [[lein-cljsbuild "1.1.3"]
+  :plugins [[lein-cljsbuild "1.1.7"]
             [lein-ancient   "0.6.15"]]
   :dependencies [[org.clojure/clojure           "1.9.0"]
                  [org.clojure/tools.logging     "0.4.0"]
@@ -9,13 +9,14 @@
                  [com.stuartsierra/component    "0.3.2"]
                  [spootnik/unilog               "0.7.22"]
                  [spootnik/uncaught             "0.5.5"]
-                 [spootnik/signal               "0.2.1"]
-                 [spootnik/watchman             "0.3.5"]
-                 [spootnik/net                  "0.2.14"]
+                 [spootnik/signal               "0.2.2"]
+                 [spootnik/watchman             "0.3.6"]
+                 [spootnik/net                  "0.3.3-beta16"]
+                 [spootnik/stevedore            "0.9.1"]
+                 [exoscale/clj-yaml             "0.5.6"]
                  [bidi                          "2.1.2"]
                  [cheshire                      "5.8.0"]
                  [org.javassist/javassist       "3.20.0-GA"]
-
                  [org.clojure/clojurescript     "1.9.946"]
                  [reagent                       "0.8.0-alpha2"]
                  [cljs-http                     "0.1.44"]]

--- a/project.clj
+++ b/project.clj
@@ -27,6 +27,7 @@
                                         :asset-path    "/warp"
                                         :optimizations :whitespace
                                         :pretty-print  false}}}}
+  :global-vars {*warn-on-reflection* true}
   :profiles {:dev     {:cljsbuild {:builds {:app {:compiler {}}}}}
              :uberjar {:omit-source true
                        :aot         :all

--- a/src/warp/dsl.clj
+++ b/src/warp/dsl.clj
@@ -1,0 +1,85 @@
+(ns warp.dsl
+  (:require [clojure.string :as str]
+            [stevedore.bash :as bash])
+  (:refer-clojure :exclude [and or not]))
+
+(defn timeout [seconds] {:timeout seconds})
+
+(defn matcher [content] {:matcher content})
+(defn and [& clauses] {:type :and :clauses clauses})
+(defn or [& clauses] {:type :or :clauses clauses})
+(defn not [clause] {:type :not :clause clause})
+(defn host [host] {:type :host :host host})
+(defn fact [fk fv] {:type :fact :fact fk :value fv})
+(defn facts [facts]
+  {:type :and :clauses (mapv #(fact (key %) (val %)) facts)})
+(defn all []  {:type :all})
+(defn none [] {:type :none})
+
+(defn commands [& content] {:commands content})
+(defn ping [] {:type :ping})
+(defn sleep [seconds] {:type :sleep :seconds seconds})
+
+(defn service*
+  ([srv] (service* srv :status))
+  ([srv action] {:type    :service
+                 :service (name srv)
+                 :action  (name action)}))
+(defmacro service
+  ([srv]
+   `(service* (name (quote ~srv))))
+  ([srv action]
+   `(service* (name (quote ~srv)) (name (quote ~action)))))
+
+(defn shell
+  [& content]
+  (reduce merge {:type :shell} content))
+
+
+(defn exits
+  [& exits]
+  {:exits (vec (flatten exits))})
+
+(defn cwd
+  [dir]
+  {:cwd dir})
+
+(defmacro script
+  [& forms]
+  `{:shell (bash/script ~@forms)})
+
+(defn scenario*
+  [script-name directives]
+  (reduce merge {:name (name script-name)} directives))
+
+(defn profiles
+  [& profiles]
+  {:profiles
+   (reduce merge {} profiles)})
+
+(defmacro profile
+  [pname content]
+  (hash-map pname content))
+
+(defmacro defscenario
+  [sym & directives]
+  (let [dirs (vec directives)]
+    `(scenario* (quote ~sym) ~dirs)))
+
+(defn read-strings
+  "Returns a sequence of forms read from string."
+  ([string]
+   (read-strings []
+                 (-> string (java.io.StringReader.)
+                   (clojure.lang.LineNumberingPushbackReader.))))
+  ([forms reader]
+   (let [form (clojure.lang.LispReader/read reader false ::EOF false)]
+     (if (= ::EOF form)
+       forms
+       (recur (conj forms (binding [*ns* (find-ns 'warp.dsl)] (eval form)))
+              reader)))))
+
+(defn load-scenario
+  [path]
+  (when-let [[_ sname] (re-matches #"(?i)^.*/(.*)\.wa?rp" path)]
+    (scenario* (str/lower-case sname) (read-strings (slurp path)))))

--- a/src/warp/parser.clj
+++ b/src/warp/parser.clj
@@ -1,0 +1,82 @@
+(ns warp.parser
+  (:require [clojure.string :as str]
+            [clojure.spec.alpha :as s]
+            [clojure.edn :as edn]
+            [warp.dsl :as dsl]
+            [clj-yaml.core :as yaml]))
+
+(defn get-extension
+  [path]
+  (when-let [[_ extension] (re-matches #"^.*\.([a-zA-Z]+)*$" path)]
+    (let [kw        (keyword (str/lower-case extension))
+          shortcuts {:clojure :edn :clj :edn :wrp :warp :yml :yaml}]
+      (shortcuts kw kw))))
+
+(defn load-error
+  [path]
+  (throw (ex-info "unknown extension for path" {:path path})))
+
+(defmulti load-config  get-extension)
+(defmethod load-config :edn     [in] (edn/read-string (slurp in)))
+(defmethod load-config :yaml    [in] (yaml/parse-string (slurp in)))
+(defmethod load-config :warp    [in] (dsl/load-scenario in))
+(defmethod load-config :default [in] (load-error in))
+
+(defn validate!
+  [input]
+  (let [conformed (s/conform ::scenario input)]
+    (when (= ::s/invalid conformed)
+      (throw (ex-info "invalid input" (s/explain-data ::scenario input))))
+    input))
+
+(defn load-unit
+  [path]
+  (validate! (load-config (str path))))
+
+(def known-action? #{"stop" "start" "status" "restart" "reload"})
+
+(s/def ::name string?)
+(s/def ::timeout pos-int?)
+
+(s/def ::clauses (s/coll-of ::matcher))
+(s/def ::host string?)
+(s/def ::fact (s/or :string string? :keyword keyword?))
+(s/def ::value string?)
+
+(defmulti matcher-type  :type)
+(defmethod matcher-type :all  [_] map?)
+(defmethod matcher-type :none [_] map?)
+(defmethod matcher-type :not  [_] (s/keys :req-un [::clause]))
+(defmethod matcher-type :and  [_] (s/keys :req-un [::clauses]))
+(defmethod matcher-type :or   [_] (s/keys :req-un [::clauses]))
+(defmethod matcher-type :host [_] (s/keys :req-un [::host]))
+(defmethod matcher-type :fact [_] (s/keys :req-un [::fact ::value]))
+
+(s/def :matcher/type    #{:all :none :not :or :and :fact :host})
+(s/def ::matcher (s/multi-spec matcher-type :matcher/type))
+(s/def ::clause ::matcher)
+
+(s/def ::service string?)
+(s/def ::interpol-val (s/and string? (partial re-matches #"\{\{[0-9*]\}\}")))
+(s/def ::known-action (s/and string? known-action?))
+(s/def ::action (s/or :known ::known-action :interpol ::interpol-val))
+(s/def ::seconds pos-int?)
+
+(s/def ::shell string?)
+(s/def ::exits (s/coll-of int?))
+(s/def ::cwd string?)
+
+(defmulti  cmd-type :type)
+(defmethod cmd-type :shell   [_] (s/keys :req-un [::shell] :opt-un [::exits ::cwd]))
+(defmethod cmd-type :ping    [_] map?)
+(defmethod cmd-type :sleep   [_] (s/keys :req-un [::seconds]))
+(defmethod cmd-type :service [_] (s/keys :req-un [::service ::action]))
+
+(s/def :cmd/type #{:shell :service :sleep :ping})
+
+(s/def ::profiles (s/map-of keyword? ::matcher))
+
+(s/def ::command (s/multi-spec cmd-type :cmd/type))
+(s/def ::commands (s/coll-of ::command))
+(s/def ::scenario (s/keys :req-un [::name ::matcher ::commands]
+                          :opt-un [::timeout ::profiles]))

--- a/src/warp/transport.clj
+++ b/src/warp/transport.clj
@@ -11,13 +11,10 @@
 (defn warp-adapter
   [mux group]
   (reify
-    pipeline/HandlerAdapter
-    (is-sharable? [this]
-      true)
-    (capabilities [this]
-      #{:channel-active :channel-read})
+    pipeline/ChannelActive
     (channel-active [this ctx]
       (channel/add-to-group group (channel/channel ctx)))
+    pipeline/HandlerAdapter
     (channel-read [this ctx msg]
       (try
         (let [payload (json/parse-string msg true)]

--- a/src/warp/transport.clj
+++ b/src/warp/transport.clj
@@ -49,7 +49,7 @@
                                  (or port 1337)))))
   (stop [this]
     (when group
-      (.close group))
+      (channel/close! group))
     (when server
       (server))
     (assoc this :group nil :server nil)))

--- a/src/warp/watcher.clj
+++ b/src/warp/watcher.clj
@@ -1,6 +1,8 @@
 (ns warp.watcher
+  (:import java.io.File)
   (:require [com.stuartsierra.component :as com]
             [clojure.edn                :as edn]
+            [clojure.java.io            :as io]
             [watch.man                  :refer [watch! ->path close]]
             [warp.parser                :refer [load-unit]]
             [clojure.tools.logging      :refer [info]]))
@@ -18,8 +20,8 @@
 (defn load-dir
   [db dir]
   (info "loading dir" dir)
-  (let [dir (java.io.File. dir)]
-    (doseq [file (.listFiles dir)
+  (let [dir (io/file dir)]
+    (doseq [^File file (file-seq dir)
             :when (.isFile file)
             :let [path (.relativize (.toPath dir) (.toPath file))]]
       (when-let [id (extract-id {:type :path :path path})]

--- a/src/warp/watcher.clj
+++ b/src/warp/watcher.clj
@@ -2,6 +2,7 @@
   (:require [com.stuartsierra.component :as com]
             [clojure.edn                :as edn]
             [watch.man                  :refer [watch! ->path close]]
+            [warp.parser                :refer [load-unit]]
             [clojure.tools.logging      :refer [info]]))
 
 (defprotocol ScenarioStore
@@ -11,11 +12,8 @@
 (defn extract-id
   [{:keys [type path]}]
   (and (= type :path)
-       (when-let [[_ id] (re-find #"^([^.].*)\.clj$" (str path))]
+       (when-let [[_ id] (re-find #"(?i)^([^.].*)\.(clojure|edn|clj|yaml|yml|warp|wrp)$" (str path))]
          (keyword id))))
-
-(def load-unit
-  (comp edn/read-string slurp str))
 
 (defn load-dir
   [db dir]


### PR DESCRIPTION
There have been dubious reports of EDN being suboptimal to create
scenarios. While this claim seems baseless and dubious, this
patch proposes two alternative formats to write scenarios:

- YAML: the lingua franca of devops
- An internal DSL

Since new ways to write scenarios mean new ways to introduce
errors, scenarios are now conformed with `clojure.spec` to
avoid letting errors sneak in.

File extensions are used to determine how to load a scenario:

- EDN scenarios are loaded for `.clj`, `.edn`, and `.clojure`
- YAML scenarios are loaded for `.yml` and `.yaml`
- Warp scenarios are loaded for `.wrp` and `.warp`

Here is an example scenario using the internal DSL:

```clojure
(timeout 30)
(matcher (none))

(profiles
  (profile :everyone (all))
  (profile :platform (facts {:facter.sp_environment "{{0}}"
                             :facter.platform       "{{1}}"}))
  (profile :host (host "{{0}}")))

(commands (service "{{0}}" "{{1}}"))
```

Thanks to [stevedore](https://github.com/pyr/stevedore), shell scripts can be written in clojure:

```clojure
(timeout 30)
(matcher (none))

(profiles
  (profile :everyone (all))
  (profile :platform (facts {:facter.sp_environment "{{0}}"
                             :facter.platform       "{{1}}"}))
  (profile :host (host "{{0}}")))
  
(commands
  (shell
    (cwd "/etc/puppet")
    (script
      (defvar revert "x{{0}}")
      (if (= @revert "xrevert")
        (rm agent-maintenance)
	(touch agent-maintenance)))))                                          
```